### PR TITLE
Fixes #10

### DIFF
--- a/class-wp-rest-cache.php
+++ b/class-wp-rest-cache.php
@@ -64,7 +64,11 @@ if ( ! class_exists( 'WP_REST_Cache' ) ) {
             $result = $result->get_data();
           }
 
-					set_transient( $key, $result, $timeout );
+					try {
+					  set_transient( $key, $result, $timeout );
+          } catch (Exception $e) {
+            error_log($e);
+          }
 				}
 			}
 

--- a/class-wp-rest-cache.php
+++ b/class-wp-rest-cache.php
@@ -60,6 +60,10 @@ if ( ! class_exists( 'WP_REST_Cache' ) ) {
 					$timeout = WP_REST_Cache_Admin::get_options( 'timeout' );
 					$timeout = apply_filters( 'rest_cache_timeout', $timeout['length'] * $timeout['period'], $timeout['length'], $timeout['period'] );
 					
+          if ( $result instanceof WP_REST_Response ) {
+            $result = $result->get_data();
+          }
+
 					set_transient( $key, $result, $timeout );
 				}
 			}


### PR DESCRIPTION
- Check if the `$response` is an instance of `WP_REST_Response` and in that case call the `get_data()` function on it to avoid serialization issues when creating the transient.
- Surround the `set_transient()` with try-catch for added safety. This way even if the serialization fails the transient just doesn't get created and we log the error.