### PR TITLE
Adding option to store cache either in disk or in transients

### DIFF
--- a/class-wp-rest-cache.php
+++ b/class-wp-rest-cache.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'WP_REST_Cache' ) ) {
 			add_filter( 'rest_pre_dispatch', array( __CLASS__, 'pre_dispatch' ), 10, 3 );
 		}
 
-		public static function pre_dispatch( $result, $server, $request ) {
+		public static function pre_dispatch( $result, WP_REST_Server $server, WP_REST_Request $request ) {
 			$request_uri = esc_url( $_SERVER['REQUEST_URI'] );
 
 			if ( method_exists( $server, 'send_headers' ) ) {
@@ -48,34 +48,143 @@ if ( ! class_exists( 'WP_REST_Cache' ) ) {
 				return $result;
 			}
 
+            $timeout = WP_REST_Cache_Admin::get_options( 'timeout' );
+            $timeout = apply_filters( 'rest_cache_timeout', $timeout['length'] * $timeout['period'], $timeout['length'], $timeout['period'] );
+
 			$skip = apply_filters( 'rest_cache_skip', WP_DEBUG, $request_uri, $server, $request );
 			if ( ! $skip ) {
-				$key = 'rest_cache_' . apply_filters( 'rest_cache_key', $request_uri, $server, $request );
-				if ( false === ( $result = get_transient( $key ) ) ) {
-					if ( is_null( self::$refresh ) ) {
-						self::$refresh = true;
-					}
-					
-					$result  = $server->dispatch( $request );
-					$timeout = WP_REST_Cache_Admin::get_options( 'timeout' );
-					$timeout = apply_filters( 'rest_cache_timeout', $timeout['length'] * $timeout['period'], $timeout['length'], $timeout['period'] );
-					
-					set_transient( $key, $result, $timeout );
-				}
+                $key = 'rest_cache_' . apply_filters('rest_cache_key', $request_uri, $server, $request);
+
+                switch (WP_REST_Cache_Admin::get_options('cache_type')) {
+                    case WP_REST_Cache_Admin::CACHE_TYPE_DISK:
+                        $result = self::deal_with_disk_cache($key, $request, $server, $timeout);
+                        break;
+
+                    case WP_REST_Cache_Admin::CACHE_TYPE_TRANSIENT:
+                    default:
+                        $result = self::deal_with_transient_cache($key, $request, $server, $timeout);
+
+                        break;
+                }
+
 			}
 
 			return $result;
 		}
 
-		public static function empty_cache() {
-			global $wpdb;
+		private static function deal_with_transient_cache($key, $request, $server, $timeout) {
+            $result = get_transient( $key );
 
-			return $wpdb->query( $wpdb->prepare( 
-				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s", 
-				'_transient_rest_cache_%', 
-				'_transient_timeout_rest_cache_%' 
-			) );
+            if ( false === $result ) {
+                if ( is_null( self::$refresh ) ) {
+                    self::$refresh = true;
+                }
+
+                $result  = $server->dispatch( $request );
+                set_transient( $key, $result, $timeout );
+            }
+
+            return $result;
+        }
+
+        /**
+         * Retrieves cache from disk (if available and not expired).
+         * Otherwise process the request as normal, but stores it
+         * serialized in Disk.
+         *
+         * @param string $key
+         * @param WP_REST_Request $request
+         * @param WP_REST_Server $server
+         * @param integer $timeout
+         *
+         * @return mixed
+         */
+        private static function deal_with_disk_cache($key, $request, $server, $timeout) {
+		    $cache_folder = rtrim(WP_REST_Cache_Admin::get_options( 'disk_cache_path' ), '/') .
+                DIRECTORY_SEPARATOR .
+                trim($key, '/');
+
+		    $cached_file = $cache_folder . '/cache';
+
+		    if( !is_dir($cache_folder) ) {
+                mkdir($cache_folder, 0744, true);
+            }
+
+            $result = false;
+
+		    if ( file_exists($cached_file) ) {
+                if ( $timeout > 0 && ( filemtime( $cached_file ) + $timeout ) > time() ) {
+                    $result = unserialize(file_get_contents($cached_file));
+                }
+            }
+
+            if ( false === $result ) {
+                if ( is_null( self::$refresh ) ) {
+                    self::$refresh = true;
+                }
+
+                $response = $server->dispatch( $request );
+
+                $result   =  $response->get_data();
+                $file = fopen($cached_file, "w");
+                fwrite($file, serialize($result));
+                fclose($file);
+            }
+
+            return $result;
+        }
+
+		public static function empty_cache() {
+
+            switch (WP_REST_Cache_Admin::get_options('cache_type')) {
+                case WP_REST_Cache_Admin::CACHE_TYPE_DISK:
+                    $return = self::delete_dir_and_files(WP_REST_Cache_Admin::get_options('disk_cache_path'));
+                    break;
+
+
+                case WP_REST_Cache_Admin::CACHE_TYPE_TRANSIENT:
+                default:
+                    global $wpdb;
+
+                    $return = $wpdb->query( $wpdb->prepare(
+                        "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+                        '_transient_rest_cache_%',
+                        '_transient_timeout_rest_cache_%'
+                    ) );
+
+                    break;
+            }
+
+            return $return;
+
 		}
+
+        public static function delete_dir_and_files($dir_path) {
+            $return = false;
+            if ( !empty($dir_path) && is_dir($dir_path) ) {
+                try{
+                    if (substr($dir_path, strlen($dir_path) - 1, 1) != '/') {
+                        $dir_path .= '/';
+                    }
+                    $files = glob($dir_path . '*', GLOB_MARK);
+                    foreach ($files as $file) {
+                        if (is_dir($file)) {
+                            self::delete_dir_and_files($file);
+                        } else {
+                            unlink($file);
+                        }
+                    }
+                    rmdir($dir_path);
+                    $return = true;
+
+                }catch (Exception $e) {
+                    $return = false;
+                }
+
+            }
+            return $return;
+        }
+
 
 	}
 

--- a/includes/admin/classes/class-wp-rest-cache-admin.php
+++ b/includes/admin/classes/class-wp-rest-cache-admin.php
@@ -7,12 +7,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'WP_REST_Cache_Admin' ) ) {
 
 	class WP_REST_Cache_Admin {
+	    const CACHE_TYPE_TRANSIENT = 1;
+        const CACHE_TYPE_DISK = 2;
 
 		private static $default = array(
 			'timeout' => array(
 				'length' => 1,
 				'period' => WEEK_IN_SECONDS,
 			),
+            'cache_type' => WP_REST_Cache_Admin::CACHE_TYPE_TRANSIENT,
+            'disk_cache_path' => '/tmp/wp-rest-api-cache'
 		);
 
 		public static function init() {

--- a/includes/admin/views/html-options.php
+++ b/includes/admin/views/html-options.php
@@ -28,6 +28,22 @@ settings_errors(); ?>
 					</select>
 				</td>
 			</tr>
+            <tr>
+                <th scope="row"><?php _e( 'Type of cache', 'wp-rest-api-cache' ); ?></th>
+                <td>
+                    <?php $cache_type = absint($options['cache_type']); ?>
+                    <select name="rest_cache_options[cache_type]">
+                        <option value="<?php echo WP_REST_Cache_Admin::CACHE_TYPE_TRANSIENT; ?>"<?php selected( $cache_type, WP_REST_Cache_Admin::CACHE_TYPE_TRANSIENT ); ?>><?php _e( 'Transient', 'wp-rest-api-cache' ); ?></option>
+                        <option value="<?php echo WP_REST_Cache_Admin::CACHE_TYPE_DISK; ?>"<?php selected( $cache_type, WP_REST_Cache_Admin::CACHE_TYPE_DISK ); ?>><?php _e( 'Disk', 'wp-rest-api-cache' ); ?></option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( 'Path to cache (if using Disk)', 'wp-rest-api-cache' ); ?></th>
+                <td>
+                    <input type="text" id="fld-cache-path" style="width: 210px;" name="rest_cache_options[disk_cache_path]" value="<?php echo esc_attr($options['disk_cache_path']); ?>">
+                </td>
+            </tr>
 			<tr>
 				<th scope="row">&nbsp;</th>
 				<td><input type="submit" class="button button-primary" value="<?php _e( 'save changes', 'wp-rest-api-cache' ); ?>"></td>


### PR DESCRIPTION
As saving cache in database is not a viable option for much projects that I work with, I would like to see the plugin being able to store cache either in disk or in transients.

**How it works:**
- Get response
- serialize it and save it disk
- when reading, check if cache file exists + check if it has not expired based on it's creation/modification time.

**What was added:**
- 2 new options in dashboard (disk or transient + path to cache in disk)
- method to delete cache in disk
- Generating and storing cache in disk

**What was changed:**
- When deleting cache we first check if the cache is transient or disk before executing